### PR TITLE
Support for using mock as a function

### DIFF
--- a/proxy-date.js
+++ b/proxy-date.js
@@ -15,6 +15,9 @@ export function mock(date) {
         return () => new Target(date) * 1
       }
       return Reflect.get(...arguments)
+    },
+    apply: function(Target) {
+        return new Target(date).toString();
     }
   })
 }


### PR DESCRIPTION
Native Date supports the following:
```js
Date(); // Note that there is not "new"
> 'Sat Jun 29 2019 01:17:21 GMT+0200 (Central European Summer Time)'
```

This change allows the mock to return the mocked string in that case